### PR TITLE
fix: gets the origin service_uuid and injects it into the content

### DIFF
--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -37,6 +37,8 @@ abstract class Message implements MessageInterface
      */
     public function toJSON(): string
     {
+        $content = $this->content;
+        $content['Origin'] = getenv('SERVICE_UUID') ?: '';
         return json_encode($this->content());
     }
 

--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -38,7 +38,7 @@ abstract class Message implements MessageInterface
     public function toJSON(): string
     {
         $content = $this->content;
-        $content['Origin'] = getenv('SERVICE_UUID') ?: '';
+        $content['Origin'] = getenv('SERVICE_UUID') ?? '';
         return json_encode($this->content());
     }
 


### PR DESCRIPTION
updates the abstract to always insert the Origin service UUID to help with recognising the origin of the message.